### PR TITLE
fix(server): stabilize getUnosPredmeta auth and error handling

### DIFF
--- a/aukcije-server/authJwt.js
+++ b/aukcije-server/authJwt.js
@@ -48,8 +48,8 @@ verifyTokenUser = (req, res, next) => {
       });
     }
     req.userId = decoded.id;
+    next();
   });
-  next();
 };
 
 const authJwt = {

--- a/aukcije-server/index.js
+++ b/aukcije-server/index.js
@@ -46,10 +46,20 @@ app.get("/api/korisnici", authJwt.verifyTokenAdmin, (req, res) => {
 
 app.get("/getUnosPredmeta", authJwt.verifyTokenUser, function (request, response) {
   connection.query("SELECT * FROM korisnik", function (error, korisniciResults) {
-    if (error) throw error;
+    if (error) {
+      console.error("Error fetching korisnici for /getUnosPredmeta:", error);
+      return response.status(500).send({
+        message: "Dogodila se greska pri dohvatu korisnika.",
+      });
+    }
 
     connection.query("SELECT * FROM kategorija", function (error, kategorijeResults) {
-      if (error) throw error;
+      if (error) {
+        console.error("Error fetching kategorije for /getUnosPredmeta:", error);
+        return response.status(500).send({
+          message: "Dogodila se greska pri dohvatu kategorija.",
+        });
+      }
 
       response.send({
         korisnici: korisniciResults,


### PR DESCRIPTION
This PR fixes the backend flow behind PostaviAukciju by making JWT verification in verifyTokenUser complete before request handling continues and by returning proper 500 responses from /getUnosPredmeta instead of throwing on database errors, which should prevent the frontend from seeing a generic Axios network error and make failures easier to diagnose.